### PR TITLE
Breaking API change

### DIFF
--- a/api.py
+++ b/api.py
@@ -27,15 +27,15 @@ def members():
         with open("voice_lst", "r") as f:
             data = json.load(f)
         if flask.request.headers.get("Response-Type") == "natural":
-            num_channels = len({k: v for (k, v) in data.items() if len(v) > 0})
-            num_members = sum(len(sub) for sub in data.values())
+            num_channels = data["occupied_channels"]
+            num_members = data["member_count"]
             # How far is too far?
             member_lst = list(
                 map(
                     lambda x: x.get("name"),
                     [
                         item
-                        for sublist in [sub for sub in data.values()]
+                        for sublist in [sub for sub in data["channels"].values()]
                         for item in sublist
                     ],
                 )
@@ -56,22 +56,4 @@ def members():
             )
         else:
             return flask.jsonify(data), 200
-    return "<h1>NO</h1>", 403
-
-
-@app.route("/members/count")
-def member_count():
-    if flask.request.headers.get("Authorization") == auth.HEADER_AUTH:
-        with open("voice_lst", "r") as f:
-            data = json.load(f)
-        return str(sum(len(sub) for sub in data.values())), 200
-    return "<h1>NO</h1>", 403
-
-
-@app.route("/channels/count")
-def occupied_channel_count():
-    if flask.request.headers.get("Authorization") == auth.HEADER_AUTH:
-        with open("voice_lst", "r") as f:
-            data = json.load(f)
-        return str(len({k: v for (k, v) in data.items() if len(v) > 0})), 200
     return "<h1>NO</h1>", 403

--- a/voice.py
+++ b/voice.py
@@ -12,10 +12,15 @@ attached_guild: discord.Guild = None
 @client.event
 async def on_voice_state_update(member=None, before=None, after=None):
     assert attached_guild is not None
-    voice_data = {}
+    member_count = 0
+    occupied_channel_count = 0
+    voice_data = {"channels": {}}
     for channel in attached_guild.voice_channels:
+        nonempty = False
         channel_member_lst = []
         for member in channel.members:
+            nonempty = True
+            member_count += 1
             channel_member_lst.append(
                 {
                     "name": member.name,
@@ -26,7 +31,11 @@ async def on_voice_state_update(member=None, before=None, after=None):
                     "server_mute": member.voice.mute,
                 }
             )
-        voice_data[str(channel)] = channel_member_lst
+        if nonempty:
+            occupied_channel_count += 1
+        voice_data["occupied_channels"] = occupied_channel_count
+        voice_data["member_count"] = member_count
+        voice_data["channels"][str(channel)] = channel_member_lst
     with open("voice_lst", "w") as f:
         json.dump(voice_data, f)
     print("[" + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "] updated")

--- a/voice.py
+++ b/voice.py
@@ -17,7 +17,14 @@ async def on_voice_state_update(member=None, before=None, after=None):
         channel_member_lst = []
         for member in channel.members:
             channel_member_lst.append(
-                {"name": member.name, "streaming": member.voice.self_stream}
+                {
+                    "name": member.name,
+                    "streaming": member.voice.self_stream,
+                    "self_mute": member.voice.self_mute,
+                    "self_deaf": member.voice.self_deaf,
+                    "server_deaf": member.voice.deaf,
+                    "server_mute": member.voice.mute,
+                }
             )
         voice_data[str(channel)] = channel_member_lst
     with open("voice_lst", "w") as f:


### PR DESCRIPTION
Channel/Member info is now under the `channels` sub-dict, and member counts and occupied channel counts are available at the top level.